### PR TITLE
Switched to own docker image for runs in GitHub actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
 
 runs:
   using: docker
-  image: Dockerfile
+  image: ghcr.io/thematchless/bump-image-version-action:latest
 
 branding:
   icon: send


### PR DESCRIPTION
- switched to own docker image to improve the GitHub action speed
- action will use the :latest tag to run the newest version for all